### PR TITLE
boost operator == and default/move constructors.

### DIFF
--- a/string/small_string.hpp
+++ b/string/small_string.hpp
@@ -2732,7 +2732,7 @@ template <typename Char, template <typename, template <class, bool> class, class
 inline auto operator==(const basic_small_string<Char, Buffer, Core, Traits, Allocator, NullTerminated>& lhs,
                        const basic_small_string<Char, Buffer, Core, Traits, Allocator, NullTerminated>& rhs) noexcept
   -> bool {
-    return lhs.size() == rhs.size() and lhs.compare(rhs) == 0;
+    return lhs.size() == rhs.size() and std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
 // small_string != small_string

--- a/string/string.hpp
+++ b/string/string.hpp
@@ -1017,7 +1017,8 @@ inline void string_core<Char>::shrinkLarge(const size_t delta) {
 template <typename E, class T = std::char_traits<E>, class A = std::allocator<E>, class Storage = string_core<E>>
 class basic_string
 {
-    static_assert(std::is_same<A, std::allocator<E>>::value or std::is_same<A, std::pmr::polymorphic_allocator<E>>::value,
+    static_assert(std::is_same<A, std::allocator<E>>::value or
+                    std::is_same<A, std::pmr::polymorphic_allocator<E>>::value,
                   "string ignores custom allocators");
 
     template <typename Ex, typename... Args>


### PR DESCRIPTION
1. std::equal is much faster than CharTraits::compare.
2. make the move or default cstr just init 1-2 bytes instead of 8 bytes.
3. do some refactoring, to make the code more clear.